### PR TITLE
Fix yarn lock file package manager error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 8
+        
+    - name: Get pnpm store directory
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        
+    - name: Setup pnpm cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+          
+    - name: Install dependencies
+      working-directory: ./task-manager
+      run: pnpm install --frozen-lockfile
+      
+    - name: Run linter
+      working-directory: ./task-manager
+      run: pnpm run lint
+      
+    - name: Build project
+      working-directory: ./task-manager
+      run: pnpm run build


### PR DESCRIPTION
Add a GitHub Actions CI workflow to correctly build pnpm projects and resolve package manager detection errors.

The previous workflow failed to detect the package manager because it was looking for `yarn.lock` instead of `pnpm-lock.yaml` and did not correctly set up pnpm or the working directory. This PR introduces a new `ci.yml` that properly configures pnpm, caches its store, and runs build steps within the `./task-manager` directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-29874b94-2731-4164-b8a3-10b70a59a3eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29874b94-2731-4164-b8a3-10b70a59a3eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

